### PR TITLE
fix: Address database schema errors

### DIFF
--- a/supabase/migrations/20250712130000_create_wishlist_items_table.sql
+++ b/supabase/migrations/20250712130000_create_wishlist_items_table.sql
@@ -5,3 +5,10 @@ CREATE TABLE wishlist_items (
     created_at TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE (user_id, product_id)
 );
+
+-- Add foreign key constraint
+ALTER TABLE public.wishlist_items
+ADD CONSTRAINT wishlist_items_product_id_fkey
+FOREIGN KEY (product_id)
+REFERENCES public.products(id)
+ON DELETE CASCADE;

--- a/supabase/migrations/20250712140000_add_frequency_to_subscriptions.sql
+++ b/supabase/migrations/20250712140000_add_frequency_to_subscriptions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subscriptions
+ADD COLUMN frequency VARCHAR(255);


### PR DESCRIPTION
This commit resolves two database schema errors:
- Fixed the foreign key relationship between the `wishlist_items` and `products` tables.
- Added the `frequency` column to the `subscriptions` table.