### PR TITLE
fix: Correct database schema and wishlist functionality

### DIFF
--- a/supabase/migrations/20250712150000_fix_schema_issues.sql
+++ b/supabase/migrations/20250712150000_fix_schema_issues.sql
@@ -1,0 +1,10 @@
+-- Add foreign key constraint to wishlist_items
+ALTER TABLE public.wishlist_items
+ADD CONSTRAINT wishlist_items_product_id_fkey
+FOREIGN KEY (product_id)
+REFERENCES public.products(id)
+ON DELETE CASCADE;
+
+-- Add frequency column to subscriptions
+ALTER TABLE public.subscriptions
+ADD COLUMN frequency VARCHAR(255);


### PR DESCRIPTION
This commit addresses two critical issues:
- It fixes the foreign key relationship between the `wishlist_items` and `products` tables to resolve the wishlist error.
- It adds the `frequency` column to the `subscriptions` table to fix the error that occurred when placing an order with a subscription.