### PR TITLE
fix: Update wishlist icon to match other icons

### DIFF
--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -33,9 +33,9 @@ import {
   FaSave,
   FaPaypal,
   FaGooglePay,
-  FaCalendarAlt
+  FaCalendarAlt,
+  FaHeart
 } from "react-icons/fa";
-import { Heart } from "lucide-react";
 import jsPDF from 'jspdf';
 
 interface Order {
@@ -630,7 +630,7 @@ const AccountPage = () => {
     { id: "dashboard", icon: <FaUser />, label: "Dashboard" },
     { id: "orders", icon: <FaBox />, label: "Orders" },
     { id: "subscriptions", icon: <FaBox />, label: "Subscriptions" },
-    { id: "wishlist", icon: <Heart />, label: "Wishlist" },
+    { id: "wishlist", icon: <FaHeart />, label: "Wishlist" },
     { id: "addresses", icon: <FaAddressBook />, label: "Addresses" },
     { id: "payments", icon: <FaCreditCard />, label: "Payments" },
     { id: "rewards", icon: <FaGift />, label: "Rewards" },


### PR DESCRIPTION
Replaced the `Heart` icon from `lucide-react` with a `FaHeart` icon from `react-icons/fa` to ensure that the wishlist icon now matches the style and size of the other icons in the account menu, providing a more consistent user interface.